### PR TITLE
Bug fixes and efficiency updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python>=4.8.0
+numpy>=1.24.0
+tqdm>=4.65.0
+mido>=1.3.0


### PR DESCRIPTION
Exit with code 1 when the video fails to open or has invalid/zero FPS; fix detect_level so 255 is in range and it never returns None; only write the final MIDI note when there was at least one valid note and clamp duration to ≥ 0; use pathlib for the default output path and make output optional. Wrap main processing in try/finally so cap.release() and cv2.destroyAllWindows() always run, including on errors. Normalize and resolve input/output paths with Path(...).resolve() to avoid path traversal. Use collections.deque(maxlen=5) for the sliding windows instead of list.pop(0); add --headless to skip the preview window for batch/CI use. Reject empty videos (framecount <= 0); handle MIDI save failures with a clear message; send errors to stderr and use exit code 1 on failure, 0 on success.